### PR TITLE
refactor: harden arena flow, interactions, and optional scoreboards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.cbhud</groupId>
     <artifactId>CastleSiege</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>CastleSiege</name>

--- a/src/main/java/me/cbhud/castlesiege/CastleSiege.java
+++ b/src/main/java/me/cbhud/castlesiege/CastleSiege.java
@@ -19,7 +19,13 @@ import me.cbhud.castlesiege.scoreboard.ScoreboardManager;
 import me.cbhud.castlesiege.team.TeamManager;
 import me.cbhud.castlesiege.utils.*;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.UUID;
 
 public final class CastleSiege extends JavaPlugin {
 
@@ -58,12 +64,22 @@ public final class CastleSiege extends JavaPlugin {
         msg = new Messages(this);
         arenaManager = new ArenaManager(this);
         arenaResetManager = new ArenaResetManager(this);
-        worldEdit = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
-        if (worldEdit == null) {
-            getLogger().severe("Regenerato or FAWE plugin not found! Disabling plugin.");
+
+        Plugin fawePlugin = Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit");
+        if (fawePlugin == null) {
+            getLogger().severe("FastAsyncWorldEdit is required for CastleSiege arena regeneration. Disabling plugin.");
             Bukkit.getPluginManager().disablePlugin(this);
             return;
         }
+
+        Plugin worldEditPlugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
+        if (worldEditPlugin instanceof WorldEditPlugin) {
+            worldEdit = (WorldEditPlugin) worldEditPlugin;
+        } else {
+            worldEdit = null;
+            getLogger().info("Using FastAsyncWorldEdit and Regenerato without a standalone WorldEdit plugin.");
+        }
+
         arenaSelector = new ArenaSelector(this);
         teamSelector = new TeamSelector(this);
 
@@ -74,7 +90,12 @@ public final class CastleSiege extends JavaPlugin {
         teamManager = new TeamManager(this, this.getConfig());
         mobManager = new MobManager(this);
 
-        scoreboardManager = new ScoreboardManager(this);
+        if (areScoreboardsEnabled()) {
+            scoreboardManager = new ScoreboardManager(this);
+        } else {
+            scoreboardManager = null;
+            getLogger().info("Scoreboards are disabled in scoreboards.yml.");
+        }
         playerManager = new PlayerManager(this);
         getServer().getPluginManager().registerEvents(new MiscEvents(this), this);
 
@@ -100,8 +121,12 @@ public final class CastleSiege extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        getDataManager().disconnect();
-        bossBar.cleanup();
+        if (dataManager != null) {
+            dataManager.disconnect();
+        }
+        if (bossBar != null) {
+            bossBar.cleanup();
+        }
     }
 
     public MobManager getMobManager() {
@@ -142,6 +167,39 @@ public final class CastleSiege extends JavaPlugin {
 
     public ScoreboardManager getScoreboardManager(){
         return scoreboardManager;
+    }
+
+    public void setupScoreboard(Player player) {
+        if (scoreboardManager != null) {
+            scoreboardManager.setupScoreboard(player);
+        }
+    }
+
+    public void updateScoreboard(Player player, String state) {
+        if (scoreboardManager != null) {
+            scoreboardManager.updateScoreboard(player, state);
+        }
+    }
+
+    public void removeScoreboard(Player player) {
+        if (scoreboardManager != null) {
+            scoreboardManager.removeScoreboard(player);
+        }
+    }
+
+    public void removeScoreboard(UUID uuid) {
+        if (scoreboardManager != null) {
+            scoreboardManager.removeScoreboard(uuid);
+        }
+    }
+
+    private boolean areScoreboardsEnabled() {
+        File file = new File(getDataFolder(), "scoreboards.yml");
+        if (!file.exists()) {
+            saveResource("scoreboards.yml", false);
+        }
+
+        return YamlConfiguration.loadConfiguration(file).getBoolean("settings.enabled", true);
     }
 
     public WorldEditPlugin getWorldEdit() {

--- a/src/main/java/me/cbhud/castlesiege/arena/Arena.java
+++ b/src/main/java/me/cbhud/castlesiege/arena/Arena.java
@@ -8,6 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
 
 import java.util.*;
 
@@ -24,7 +25,7 @@ public class Arena {
     private final int maxPlayers;
     private final int minPlayers;
 
-    // ✅ store UUIDs, not Player objects
+    // I store UUIDs instead of Player objects so arena membership does not keep player instances alive.
     private final Set<UUID> playerIds = new HashSet<>();
 
     private ArenaState state = ArenaState.WAITING;
@@ -116,7 +117,7 @@ public class Arena {
     public Location getDefendersSpawn() { return defendersSpawn; }
     public Location getTeamSpawn(Team team) { return (team == Team.Attackers) ? attackersSpawn : defendersSpawn; }
 
-    public Location getLSpawn() { return lobbySpawn; } // kept for compatibility
+    public Location getLSpawn() { return lobbySpawn; } // I keep this alias for compatibility.
     public Location getKingSpawn() { return kingSpawn; }
 
     public Location getKSpawn() {
@@ -174,10 +175,10 @@ public class Arena {
         // In-game join = spectator
         if (state == ArenaState.IN_GAME) {
             playerIds.add(uuid);
-            plugin.getPlayerManager().setPlayerAsSpectating(player);
 
             Location ks = resolveKingSpawn();
             if (ks != null) player.teleport(ks);
+            plugin.getPlayerManager().setPlayerAsSpectating(player);
 
             sendTitleSafe(player, "spectatorTitle", 10, 70, 20);
             return false;
@@ -188,11 +189,10 @@ public class Arena {
         // Try team join; if fail -> spectator
         if (!teamManager.tryRandomTeamJoin(player)) {
             playerIds.add(uuid);
-            plugin.getPlayerManager().setPlayerAsSpectating(player);
 
             Location ks = resolveKingSpawn();
             if (ks != null) player.teleport(ks);
-
+            plugin.getPlayerManager().setPlayerAsSpectating(player);
             sendTitleSafe(player, "spectatorTitle", 10, 70, 20);
             return false;
         }
@@ -215,6 +215,7 @@ public class Arena {
     public void removePlayer(Player player) {
         if (player == null) return;
 
+        Team removedTeam = teamManager.getTeam(player);
         playerIds.remove(player.getUniqueId());
         teamManager.removePlayerFromTeam(player);
 
@@ -227,12 +228,15 @@ public class Arena {
         }
 
         plugin.getArenaManager().unmapPlayer(player.getUniqueId());
+        endGameIfNoDefendersRemain(removedTeam);
     }
 
-    /** Hardcore: remove them from team only (kept compatible with your current DeathEvent). */
+    /** I remove hardcore deaths from their team while leaving them in the arena as spectators. */
     public void removeHardcore(Player player) {
         if (player == null) return;
+        Team removedTeam = teamManager.getTeam(player);
         teamManager.removePlayerFromTeam(player);
+        endGameIfNoDefendersRemain(removedTeam);
     }
 
     /* ------------------------- Game flow ------------------------- */
@@ -275,7 +279,7 @@ public class Arena {
 
         state = ArenaState.ENDED;
 
-        // Use the new timer flag if you applied the TimerManager changes
+        // I use the timer flag so winner logic does not depend on task ids.
         boolean attackersWon = !timerManager.didCountdownExpire();
         if (teamManager.getPlayersInTeam(Team.Attackers) == 0) attackersWon = false;
 
@@ -310,7 +314,7 @@ public class Arena {
             }
 
             p.playSound(p.getLocation(), winSound, 1.0f, 1.0f);
-            plugin.getScoreboardManager().updateScoreboard(p, "end");
+            plugin.updateScoreboard(p, "end");
 
             sendLines(p, winMessageKey);
             sendTitleSafe(p, winTitleKey, 10, 70, 20);
@@ -321,7 +325,8 @@ public class Arena {
         int coinsReward = plugin.getConfigManager().getCoinsOnWin();
         for (UUID uuid : teamManager.getTeamMemberIds(winningTeam)) {
             plugin.getDataManager().addPlayerCoins(uuid, coinsReward);
-            plugin.getDataManager().incrementWins(uuid, 1);
+            plugin.getDataManager().incrementWins(uuid);
+            sendWinCoinsMessage(uuid, coinsReward);
         }
 
         // Cleanup players via ArenaManager (single source of truth)
@@ -377,13 +382,31 @@ public class Arena {
                         sendTitleSafe(p, "attackersTitle", 10, 100, 20);
                     }
                     if (plugin.getBBar().isEnabled()) {
-                        plugin.getBBar().showZombieHealthBarToPlayer(
-                                plugin.getMobManager().getKingZombie(kingSpawn.getWorld()), p);
+                        showKingBossBarToPlayer(p);
                     }
                     p.playSound(p.getLocation(), Sound.ENTITY_WITHER_SPAWN, 1.0f, 1.0f);
                 }, 20L);
             }
         }
+    }
+
+    private void endGameIfNoDefendersRemain(Team removedTeam) {
+        if (state != ArenaState.IN_GAME || removedTeam != Team.Defenders) return;
+        if (teamManager.getPlayersInTeam(Team.Defenders) > 0) return;
+        if (teamManager.getPlayersInTeam(Team.Attackers) <= 0) return;
+
+        plugin.getMobManager().removeCustomZombie(this);
+        endGame();
+    }
+
+    private void showKingBossBarToPlayer(Player player) {
+        Location kingLocation = resolveKingSpawn();
+        if (kingLocation == null || kingLocation.getWorld() == null) return;
+
+        Zombie king = plugin.getMobManager().getKingZombie(kingLocation.getWorld());
+        if (king == null || !king.isValid() || king.isDead()) return;
+
+        plugin.getBBar().showZombieHealthBarToPlayer(king, player);
     }
 
     /* ------------------------- Message helpers ------------------------- */
@@ -404,6 +427,17 @@ public class Arena {
         String line2 = title.size() >= 2 ? title.get(1) : "";
 
         player.sendTitle(line1, line2, fadeIn, stay, fadeOut);
+    }
+
+    private void sendWinCoinsMessage(UUID uuid, int coinsReward) {
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null || !player.isOnline()) return;
+
+        for (String line : plugin.getMsg().getMessage("win-coins-received", player)) {
+            if (line != null && !line.isEmpty()) {
+                player.sendMessage(line.replace("{coins}", String.valueOf(coinsReward)));
+            }
+        }
     }
 
     /* ------------------------- Setters ------------------------- */

--- a/src/main/java/me/cbhud/castlesiege/arena/ArenaManager.java
+++ b/src/main/java/me/cbhud/castlesiege/arena/ArenaManager.java
@@ -81,13 +81,12 @@ public class ArenaManager {
             removePlayerFromArena(player); // removes mapping + calls arena.removePlayer
         }
 
-        // ✅ Map FIRST so any downstream code (kits/teams) can resolve arena
+        // I map first so downstream kit and team code can resolve the arena during join.
         playerArenaMap.put(playerId, arena);
 
         arena.addPlayer(player);
 
-        // ✅ If addPlayer didn't actually keep them in this arena, rollback mapping
-        // (works with your UUID-based Arena: containsPlayer(uuid) or getNoPlayers checks)
+        // I roll back the map entry if addPlayer did not actually keep them in this arena.
         if (!arena.containsPlayer(playerId)) {
             playerArenaMap.remove(playerId);
         }
@@ -112,6 +111,32 @@ public class ArenaManager {
         loadArenas();
     }
 
+    /**
+     * Reloads one arena from arenas.yml without clearing other arenas or player mappings.
+     * Returns false if the arena is active or has players, because replacing it would drop runtime state.
+     */
+    public boolean reloadArena(String arenaId) {
+        if (arenaId == null || arenaId.isBlank()) return false;
+
+        Arena existing = arenas.get(arenaId);
+        if (existing != null && (existing.getState() != ArenaState.WAITING || existing.getNoPlayers() > 0)) {
+            plugin.getLogger().warning("Arena '" + arenaId + "' was saved but not hot-reloaded because it is active or has players.");
+            return false;
+        }
+
+        this.config = YamlConfiguration.loadConfiguration(configFile);
+
+        ConfigurationSection section = getArenaSection(arenaId);
+        if (section == null) return false;
+
+        Arena arena = loadArena(arenaId, section);
+        if (arena == null) return false;
+
+        arenas.put(arenaId, arena);
+        plugin.getArenaResetManager().reload();
+        return true;
+    }
+
     /* ------------------------- Arena loading ------------------------- */
 
     private void loadArenas() {
@@ -122,39 +147,41 @@ public class ArenaManager {
             ConfigurationSection section = arenasSection.getConfigurationSection(arenaId);
             if (section == null) continue;
 
-            Location lobbySpawn = parseLocation(section.getString("lobby-spawn"), arenaId, "lobby-spawn");
-            Location kingSpawn = parseLocation(section.getString("king-spawn"), arenaId, "king-spawn");
-            Location defendersSpawn = parseLocation(section.getString("defenders-spawn"), arenaId, "defenders-spawn");
-            Location attackersSpawn = parseLocation(section.getString("attackers-spawn"), arenaId, "attackers-spawn");
-
-            int autoStart = section.getInt("auto-start", 60);
-            int countdown = section.getInt("game-timer", 300);
-            int minPlayers = section.getInt("min-players", 2);
-            int maxPlayers = section.getInt("max-players", 16);
-            boolean hardcore = section.getBoolean("hardcore", false);
-
-            // Determine worldName safely
-            String worldName = null;
-            if (kingSpawn != null && kingSpawn.getWorld() != null) {
-                worldName = kingSpawn.getWorld().getName();
-            } else {
-                String raw = section.getString("king-spawn");
-                if (raw != null) {
-                    String[] parts = raw.split(",");
-                    if (parts.length >= 1) worldName = parts[0].trim();
-                }
-            }
-
-            if (worldName == null || worldName.isBlank()) {
-                plugin.getLogger().warning("Arena '" + arenaId + "' has no valid worldName (king-spawn missing/invalid). Skipping arena load.");
-                continue;
-            }
-
-            Arena arena = new Arena(plugin, arenaId, lobbySpawn, kingSpawn, attackersSpawn, defendersSpawn,
-                    maxPlayers, minPlayers, autoStart, countdown, worldName, hardcore);
-
-            arenas.put(arenaId, arena);
+            Arena arena = loadArena(arenaId, section);
+            if (arena != null) arenas.put(arenaId, arena);
         }
+    }
+
+    private Arena loadArena(String arenaId, ConfigurationSection section) {
+        Location lobbySpawn = parseLocation(section.getString("lobby-spawn"), arenaId, "lobby-spawn");
+        Location kingSpawn = parseLocation(section.getString("king-spawn"), arenaId, "king-spawn");
+        Location defendersSpawn = parseLocation(section.getString("defenders-spawn"), arenaId, "defenders-spawn");
+        Location attackersSpawn = parseLocation(section.getString("attackers-spawn"), arenaId, "attackers-spawn");
+
+        int autoStart = section.getInt("auto-start", 60);
+        int countdown = section.getInt("game-timer", 300);
+        int minPlayers = section.getInt("min-players", 2);
+        int maxPlayers = section.getInt("max-players", 16);
+        boolean hardcore = section.getBoolean("hardcore", false);
+
+        String worldName = null;
+        if (kingSpawn != null && kingSpawn.getWorld() != null) {
+            worldName = kingSpawn.getWorld().getName();
+        } else {
+            String raw = section.getString("king-spawn");
+            if (raw != null) {
+                String[] parts = raw.split(",");
+                if (parts.length >= 1) worldName = parts[0].trim();
+            }
+        }
+
+        if (worldName == null || worldName.isBlank()) {
+            plugin.getLogger().warning("Arena '" + arenaId + "' has no valid worldName (king-spawn missing/invalid). Skipping arena load.");
+            return null;
+        }
+
+        return new Arena(plugin, arenaId, lobbySpawn, kingSpawn, attackersSpawn, defendersSpawn,
+                maxPlayers, minPlayers, autoStart, countdown, worldName, hardcore);
     }
 
     /* ------------------------- Config helpers ------------------------- */

--- a/src/main/java/me/cbhud/castlesiege/arena/ArenaTimerManager.java
+++ b/src/main/java/me/cbhud/castlesiege/arena/ArenaTimerManager.java
@@ -63,7 +63,7 @@ public class ArenaTimerManager {
             // Update scoreboard for current arena players (copy to avoid CME)
             for (Player p : arena.getOnlinePlayersSnapshot()) {
                 if (p == null || !p.isOnline()) continue;
-                plugin.getScoreboardManager().updateScoreboard(p, "in-game");
+                plugin.updateScoreboard(p, "in-game");
             }
 
             currentCountdownTimer--;

--- a/src/main/java/me/cbhud/castlesiege/cmd/CseCommand.java
+++ b/src/main/java/me/cbhud/castlesiege/cmd/CseCommand.java
@@ -489,7 +489,7 @@ public class CseCommand implements CommandExecutor, TabCompleter {
         if (!root.equals("cse")) tokens.add(root);
         tokens.addAll(Arrays.asList(args));
 
-        // Example: /cse <sub>
+        // I complete the first argument after /cse.
         if (tokens.size() == 1) {
             return partial(tokens.get(0), List.of("join", "randomjoin", "leave", "stats", "arena", "coins", "setlobby"));
         }

--- a/src/main/java/me/cbhud/castlesiege/event/CustomItemInteractionHandler.java
+++ b/src/main/java/me/cbhud/castlesiege/event/CustomItemInteractionHandler.java
@@ -1,0 +1,86 @@
+package me.cbhud.castlesiege.event;
+
+import me.cbhud.castlesiege.CastleSiege;
+import me.cbhud.castlesiege.kit.CustomItem;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+class CustomItemInteractionHandler {
+
+    private final CastleSiege plugin;
+    private final Map<UUID, Map<String, Long>> cooldowns = new HashMap<>();
+
+    CustomItemInteractionHandler(CastleSiege plugin) {
+        this.plugin = plugin;
+    }
+
+    boolean handle(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem();
+        Optional<CustomItem> match = plugin.getItemManager().matchCustomItem(item);
+        if (match.isEmpty()) return false;
+
+        CustomItem customItem = match.get();
+
+        if (item.getType() == Material.MUSHROOM_STEW) {
+            removeOneItem(player, item);
+            applyEffects(player, customItem);
+            return true;
+        }
+
+        if (!canUse(player, customItem)) {
+            return false;
+        }
+
+        applyEffects(player, customItem);
+        return true;
+    }
+
+    void clearCooldowns(UUID uuid) {
+        cooldowns.remove(uuid);
+    }
+
+    private boolean canUse(Player player, CustomItem customItem) {
+        long cooldown = customItem.getCooldown();
+        if (cooldown <= 0) {
+            return true;
+        }
+
+        UUID uuid = player.getUniqueId();
+        long now = System.currentTimeMillis();
+        long lastUsed = cooldowns
+                .computeIfAbsent(uuid, key -> new HashMap<>())
+                .getOrDefault(customItem.getId(), 0L);
+
+        if (now - lastUsed < cooldown) {
+            int seconds = (int) ((cooldown - (now - lastUsed)) / 1000);
+            String msg = plugin.getMsg().getGuiMessage("customitem-cooldown").get(0);
+            msg = msg.replace("{seconds}", String.valueOf(seconds));
+            player.sendMessage(msg);
+            return false;
+        }
+
+        cooldowns.get(uuid).put(customItem.getId(), now);
+        return true;
+    }
+
+    private void applyEffects(Player player, CustomItem customItem) {
+        for (PotionEffect effect : customItem.getEffects()) {
+            player.addPotionEffect(effect);
+        }
+    }
+
+    private void removeOneItem(Player player, ItemStack item) {
+        ItemStack clone = item.clone();
+        clone.setAmount(1);
+        player.getInventory().removeItem(clone);
+    }
+}

--- a/src/main/java/me/cbhud/castlesiege/event/DamageEvent.java
+++ b/src/main/java/me/cbhud/castlesiege/event/DamageEvent.java
@@ -24,7 +24,7 @@ public class DamageEvent implements Listener {
     public void onDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player damagedPlayer)) return;
 
-        // No damage outside PLAYING state (your original behavior)
+        // I block damage unless the player is actively playing.
         if (plugin.getPlayerManager().getPlayerState(damagedPlayer) != PlayerState.PLAYING) {
             event.setCancelled(true);
             return;

--- a/src/main/java/me/cbhud/castlesiege/event/JoinEvent.java
+++ b/src/main/java/me/cbhud/castlesiege/event/JoinEvent.java
@@ -35,7 +35,8 @@ public class JoinEvent implements Listener {
 
         plugin.getArenaManager().removePlayerFromArena(p);
 
-        plugin.getScoreboardManager().removeScoreboard(p);
+        plugin.removeScoreboard(p);
+        plugin.getPlayerKitManager().clearSelectedKit(p);
         plugin.getPlayerManager().clearPlayerState(p);
         plugin.getNameTagManager().removeNametag(p);
     }

--- a/src/main/java/me/cbhud/castlesiege/event/MenuInteractionHandler.java
+++ b/src/main/java/me/cbhud/castlesiege/event/MenuInteractionHandler.java
@@ -1,0 +1,56 @@
+package me.cbhud.castlesiege.event;
+
+import me.cbhud.castlesiege.CastleSiege;
+import me.cbhud.castlesiege.arena.Arena;
+import me.cbhud.castlesiege.arena.ArenaState;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+class MenuInteractionHandler {
+
+    private final CastleSiege plugin;
+
+    MenuInteractionHandler(CastleSiege plugin) {
+        this.plugin = plugin;
+    }
+
+    boolean handleLobbyItem(PlayerInteractEvent event) {
+        if (event.getItem().getType() != Material.EMERALD) {
+            return false;
+        }
+
+        plugin.getArenaSelector().open(event.getPlayer());
+        return true;
+    }
+
+    boolean handleWaitingArenaItem(PlayerInteractEvent event, Arena arena) {
+        Material type = event.getItem().getType();
+        if (arena.getState() != ArenaState.WAITING) {
+            return false;
+        }
+
+        if (type == Material.CLOCK) {
+            plugin.getTeamSelector().open(event.getPlayer());
+            return true;
+        }
+
+        if (type == Material.NETHER_STAR) {
+            plugin.getKitSelector().open(event.getPlayer());
+            return true;
+        }
+
+        return false;
+    }
+
+    boolean handleLeaveItem(PlayerInteractEvent event, Arena arena) {
+        if (event.getItem().getType() != Material.RED_DYE) {
+            return false;
+        }
+
+        Player player = event.getPlayer();
+        player.sendMessage(plugin.getMsg().getMessage("leaveArena", player).get(0));
+        arena.removePlayer(player);
+        return true;
+    }
+}

--- a/src/main/java/me/cbhud/castlesiege/event/RightClickEffects.java
+++ b/src/main/java/me/cbhud/castlesiege/event/RightClickEffects.java
@@ -3,36 +3,27 @@ package me.cbhud.castlesiege.event;
 import me.cbhud.castlesiege.CastleSiege;
 import me.cbhud.castlesiege.arena.Arena;
 import me.cbhud.castlesiege.arena.ArenaState;
-import me.cbhud.castlesiege.kit.CustomItem;
-import me.cbhud.castlesiege.team.Team;
-import org.bukkit.Material;
-import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.Vector;
-
-import java.util.*;
 
 public class RightClickEffects implements Listener {
 
     private final CastleSiege plugin;
-    private final Random rand = new Random();
-    private static final int EFFECT_DURATION = 100;
-    private final Map<UUID, Long> attackCooldowns = new HashMap<>();
-    private final Map<UUID, Long> supportCooldowns = new HashMap<>();
-    private long ATTACK_COOLDOWN;
-    private long SUPPORT_COOLDOWN;
+    private final MenuInteractionHandler menuHandler;
+    private final ThrowableAxeHandler axeHandler;
+    private final WizardSpellHandler wizardSpellHandler;
+    private final CustomItemInteractionHandler customItemHandler;
 
     public RightClickEffects(CastleSiege plugin) {
         this.plugin = plugin;
-        this.ATTACK_COOLDOWN = plugin.getConfigManager().getConfig().getInt("wizardAttackSpellCooldown", 30) * 1000;
-        this.SUPPORT_COOLDOWN = plugin.getConfigManager().getConfig().getInt("wizardSupportSpellCooldown", 30) * 1000;
+        this.menuHandler = new MenuInteractionHandler(plugin);
+        this.axeHandler = new ThrowableAxeHandler(plugin);
+        this.wizardSpellHandler = new WizardSpellHandler(plugin);
+        this.customItemHandler = new CustomItemInteractionHandler(plugin);
     }
 
     @EventHandler
@@ -41,196 +32,46 @@ public class RightClickEffects implements Listener {
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack clickedItem = event.getItem();
-
         if (clickedItem == null) {
             return;
         }
 
-        Arena arena = plugin.getArenaManager().getArenaByPlayer(player.getUniqueId());
-
-        if (clickedItem.getType() == Material.GOLDEN_AXE && arena.getState() == ArenaState.IN_GAME) {
-            throwAxe(player);
-            player.getInventory().remove(clickedItem);
-            event.setCancelled(true);
+        if (menuHandler.handleLobbyItem(event)) {
             return;
         }
 
-        // Example: If player right-clicks with a blaze rod (just as example for wizard attack spell)
-        if (clickedItem.getType() == Material.BLAZE_ROD) {
-            UUID uuid = player.getUniqueId();
-            long now = System.currentTimeMillis();
-
-            Long lastUsed = attackCooldowns.getOrDefault(uuid, 0L);
-            if (now - lastUsed < ATTACK_COOLDOWN) {
-                int seconds = (int) ((ATTACK_COOLDOWN - (now - lastUsed)) / 1000);
-                String msg = plugin.getMsg().getGuiMessage("customitem-cooldown").get(0);
-                msg = msg.replace("{seconds}", String.valueOf(seconds));
-                player.sendMessage(msg);
-                return;
-            }
-            attackCooldowns.put(uuid, now);
-
-            for (Player nearbyPlayer : player.getWorld().getPlayers()) {
-                if (nearbyPlayer.getLocation().distance(player.getLocation()) <= 10 &&
-                        plugin.getArenaManager().getArenaByPlayer(uuid).getTeam(nearbyPlayer) == Team.Attackers) {
-                    applyRandomEffect(nearbyPlayer);
-                    player.sendMessage(plugin.getMsg().getGuiMessage("wizardAttackSpell").get(0));
-                }
-            }
-
-            event.setCancelled(true);
+        Arena arena = plugin.getArenaManager().getArenaByPlayer(event.getPlayer().getUniqueId());
+        if (arena == null) {
             return;
         }
 
-// Example: If player right-clicks with a stick (example support spell)
-        if (clickedItem.getType() == Material.STICK) {
-            UUID uuid = player.getUniqueId();
-            long now = System.currentTimeMillis();
-
-            Long lastUsed = supportCooldowns.getOrDefault(uuid, 0L);
-            if (now - lastUsed < SUPPORT_COOLDOWN) {
-                int seconds = (int) ((SUPPORT_COOLDOWN - (now - lastUsed)) / 1000);
-                String msg = plugin.getMsg().getGuiMessage("customitem-cooldown").get(0);
-                msg = msg.replace("{seconds}", String.valueOf(seconds));
-                player.sendMessage(msg);
-                return;
-            }
-            supportCooldowns.put(uuid, now);
-
-            for (Player nearbyPlayer : player.getWorld().getPlayers()) {
-                if (nearbyPlayer.getLocation().distance(player.getLocation()) <= 10 &&
-                        plugin.getArenaManager().getArenaByPlayer(uuid).getTeam(nearbyPlayer) == Team.Defenders) {
-                    applyRandomSupportEffect(nearbyPlayer);
-                    player.sendMessage(plugin.getMsg().getGuiMessage("wizardSupportSpell").get(0));
-                }
-            }
-
-            event.setCancelled(true);
+        if (axeHandler.handle(event, arena)) {
             return;
         }
 
-        if (clickedItem.getType() == Material.EMERALD) {
-            plugin.getArenaSelector().open(player);
+        if (wizardSpellHandler.handle(event, arena)) {
             return;
         }
 
-        if (clickedItem.getType() == Material.CLOCK && arena != null && arena.getState() == ArenaState.WAITING) {
-            plugin.getTeamSelector().open(player);
+        if (menuHandler.handleWaitingArenaItem(event, arena)) {
             return;
         }
 
-        if (clickedItem.getType() == Material.NETHER_STAR && arena != null && arena.getState() == ArenaState.WAITING) {
-            plugin.getKitSelector().open(player);
+        if (arena.getState() == ArenaState.ENDED) {
             return;
         }
 
-        if (arena == null || arena.getState() == ArenaState.ENDED) {
+        if (menuHandler.handleLeaveItem(event, arena)) {
             return;
         }
 
-        if (clickedItem.getType() == Material.RED_DYE) {
-            player.sendMessage(plugin.getMsg().getMessage("leaveArena", player).get(0));
-            arena.removePlayer(player);
-            return;
-        }
-
-        useSpecialItem(player, clickedItem);
-
+        customItemHandler.handle(event);
     }
 
-    private final Map<UUID, Map<String, Long>> cooldowns = new HashMap<>();
-
-    private boolean useSpecialItem(Player player, ItemStack item) {
-        UUID uuid = player.getUniqueId();
-        long now = System.currentTimeMillis();
-
-        Optional<CustomItem> match = plugin.getItemManager().matchCustomItem(item);
-        if (match.isEmpty()) return false;
-
-        CustomItem customItem = match.get();
-
-        Material mat = item.getType();
-        if (mat == Material.MUSHROOM_STEW) {
-            removeOneItem(player, item);
-
-            for (PotionEffect effect : customItem.getEffects()) {
-                player.addPotionEffect(effect);
-            }
-
-            return true;
-        }
-
-        long cooldown = customItem.getCooldown();
-
-        if (cooldown > 0) {
-            long lastUsed = cooldowns
-                    .computeIfAbsent(uuid, k -> new HashMap<>())
-                    .getOrDefault(customItem.getId(), 0L);
-
-            if (now - lastUsed < cooldown) {
-                int seconds = (int) ((cooldown - (now - lastUsed)) / 1000);
-                String msg = plugin.getMsg().getGuiMessage("customitem-cooldown").get(0);
-                msg = msg.replace("{seconds}", String.valueOf(seconds));
-                player.sendMessage(msg);
-                return false;
-            }
-
-            cooldowns.get(uuid).put(customItem.getId(), now);
-        }
-
-        for (PotionEffect effect : customItem.getEffects()) {
-            player.addPotionEffect(effect);
-        }
-
-        return true;
-    }
-
-    private void removeOneItem(Player player, ItemStack item) {
-        ItemStack clone = item.clone();
-        clone.setAmount(1);
-        player.getInventory().removeItem(clone);
-    }
-
-    private void throwAxe(Player player) {
-        try {
-            Item axe = player.getWorld().dropItem(player.getEyeLocation(), player.getInventory().getItemInMainHand());
-            axe.setVelocity(player.getEyeLocation().getDirection().multiply(1.1));
-            player.getInventory().getItemInMainHand().setAmount(0);
-
-            new BukkitRunnable() {
-                public void run() {
-                    for (Entity ent : axe.getNearbyEntities(0.5, 0.5, 0.5)) {
-                        if (ent instanceof LivingEntity && ent != player) {
-                            LivingEntity target = (LivingEntity) ent;
-                            target.damage(2.5);
-                            axe.setVelocity(new Vector(0, 0, 0));
-                            this.cancel();
-                            axe.remove();
-                        }
-                    }
-                    if (axe.isOnGround()) {
-                        axe.setVelocity(new Vector(0, 0, 0));
-                        axe.remove();
-                        this.cancel();
-                    }
-                }
-            }.runTaskTimer(this.plugin, 0L, 1L);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-    }
-
-    private void applyRandomEffect(Player player) {
-        PotionEffectType[] effects = {PotionEffectType.POISON, PotionEffectType.SLOW, PotionEffectType.BLINDNESS};
-        PotionEffectType effect = effects[rand.nextInt(effects.length)];
-        player.addPotionEffect(new PotionEffect(effect, EFFECT_DURATION, 1));
-    }
-
-    private void applyRandomSupportEffect(Player player) {
-        PotionEffectType[] effects = {PotionEffectType.REGENERATION, PotionEffectType.ABSORPTION, PotionEffectType.SPEED};
-        PotionEffectType effect = effects[rand.nextInt(effects.length)];
-        player.addPotionEffect(new PotionEffect(effect, EFFECT_DURATION, 1));
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        wizardSpellHandler.clearCooldowns(event.getPlayer().getUniqueId());
+        customItemHandler.clearCooldowns(event.getPlayer().getUniqueId());
     }
 }

--- a/src/main/java/me/cbhud/castlesiege/event/ThrowableAxeHandler.java
+++ b/src/main/java/me/cbhud/castlesiege/event/ThrowableAxeHandler.java
@@ -1,0 +1,62 @@
+package me.cbhud.castlesiege.event;
+
+import me.cbhud.castlesiege.CastleSiege;
+import me.cbhud.castlesiege.arena.Arena;
+import me.cbhud.castlesiege.arena.ArenaState;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+class ThrowableAxeHandler {
+
+    private final CastleSiege plugin;
+
+    ThrowableAxeHandler(CastleSiege plugin) {
+        this.plugin = plugin;
+    }
+
+    boolean handle(PlayerInteractEvent event, Arena arena) {
+        if (event.getItem().getType() != Material.GOLDEN_AXE || arena.getState() != ArenaState.IN_GAME) {
+            return false;
+        }
+
+        throwAxe(event.getPlayer());
+        event.getPlayer().getInventory().remove(event.getItem());
+        event.setCancelled(true);
+        return true;
+    }
+
+    private void throwAxe(Player player) {
+        try {
+            Item axe = player.getWorld().dropItem(player.getEyeLocation(), player.getInventory().getItemInMainHand());
+            axe.setVelocity(player.getEyeLocation().getDirection().multiply(1.1));
+            player.getInventory().getItemInMainHand().setAmount(0);
+
+            new BukkitRunnable() {
+                public void run() {
+                    for (Entity ent : axe.getNearbyEntities(0.5, 0.5, 0.5)) {
+                        if (ent instanceof LivingEntity && ent != player) {
+                            LivingEntity target = (LivingEntity) ent;
+                            target.damage(2.5);
+                            axe.setVelocity(new Vector(0, 0, 0));
+                            this.cancel();
+                            axe.remove();
+                        }
+                    }
+                    if (axe.isOnGround()) {
+                        axe.setVelocity(new Vector(0, 0, 0));
+                        axe.remove();
+                        this.cancel();
+                    }
+                }
+            }.runTaskTimer(this.plugin, 0L, 1L);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/me/cbhud/castlesiege/event/WizardSpellHandler.java
+++ b/src/main/java/me/cbhud/castlesiege/event/WizardSpellHandler.java
@@ -1,0 +1,108 @@
+package me.cbhud.castlesiege.event;
+
+import me.cbhud.castlesiege.CastleSiege;
+import me.cbhud.castlesiege.arena.Arena;
+import me.cbhud.castlesiege.team.Team;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+class WizardSpellHandler {
+
+    private static final int EFFECT_DURATION = 100;
+
+    private final CastleSiege plugin;
+    private final Random random = new Random();
+    private final Map<UUID, Long> attackCooldowns = new HashMap<>();
+    private final Map<UUID, Long> supportCooldowns = new HashMap<>();
+    private final long attackCooldown;
+    private final long supportCooldown;
+
+    WizardSpellHandler(CastleSiege plugin) {
+        this.plugin = plugin;
+        this.attackCooldown = plugin.getConfigManager().getConfig().getInt("wizardAttackSpellCooldown", 30) * 1000L;
+        this.supportCooldown = plugin.getConfigManager().getConfig().getInt("wizardSupportSpellCooldown", 30) * 1000L;
+    }
+
+    boolean handle(PlayerInteractEvent event, Arena arena) {
+        Material type = event.getItem().getType();
+
+        if (type == Material.BLAZE_ROD) {
+            castSpell(event, arena, attackCooldowns, attackCooldown, Team.Attackers, true);
+            return true;
+        }
+
+        if (type == Material.STICK) {
+            castSpell(event, arena, supportCooldowns, supportCooldown, Team.Defenders, false);
+            return true;
+        }
+
+        return false;
+    }
+
+    void clearCooldowns(UUID uuid) {
+        attackCooldowns.remove(uuid);
+        supportCooldowns.remove(uuid);
+    }
+
+    private void castSpell(
+            PlayerInteractEvent event,
+            Arena arena,
+            Map<UUID, Long> cooldowns,
+            long cooldown,
+            Team affectedTeam,
+            boolean attackSpell
+    ) {
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        long now = System.currentTimeMillis();
+
+        Long lastUsed = cooldowns.getOrDefault(uuid, 0L);
+        if (now - lastUsed < cooldown) {
+            int seconds = (int) ((cooldown - (now - lastUsed)) / 1000);
+            sendCooldown(player, seconds);
+            return;
+        }
+        cooldowns.put(uuid, now);
+
+        for (Player nearbyPlayer : player.getWorld().getPlayers()) {
+            if (nearbyPlayer.getLocation().distance(player.getLocation()) <= 10
+                    && arena.getTeam(nearbyPlayer) == affectedTeam) {
+                if (attackSpell) {
+                    applyRandomAttackEffect(nearbyPlayer);
+                } else {
+                    applyRandomSupportEffect(nearbyPlayer);
+                }
+                player.sendMessage(plugin.getMsg().getGuiMessage(
+                        attackSpell ? "wizardAttackSpell" : "wizardSupportSpell").get(0));
+            }
+        }
+
+        event.setCancelled(true);
+    }
+
+    private void sendCooldown(Player player, int seconds) {
+        String msg = plugin.getMsg().getGuiMessage("customitem-cooldown").get(0);
+        msg = msg.replace("{seconds}", String.valueOf(seconds));
+        player.sendMessage(msg);
+    }
+
+    private void applyRandomAttackEffect(Player player) {
+        PotionEffectType[] effects = {PotionEffectType.POISON, PotionEffectType.SLOW, PotionEffectType.BLINDNESS};
+        PotionEffectType effect = effects[random.nextInt(effects.length)];
+        player.addPotionEffect(new PotionEffect(effect, EFFECT_DURATION, 1));
+    }
+
+    private void applyRandomSupportEffect(Player player) {
+        PotionEffectType[] effects = {PotionEffectType.REGENERATION, PotionEffectType.ABSORPTION, PotionEffectType.SPEED};
+        PotionEffectType effect = effects[random.nextInt(effects.length)];
+        player.addPotionEffect(new PotionEffect(effect, EFFECT_DURATION, 1));
+    }
+}

--- a/src/main/java/me/cbhud/castlesiege/gui/ArenaEditChatListener.java
+++ b/src/main/java/me/cbhud/castlesiege/gui/ArenaEditChatListener.java
@@ -98,8 +98,10 @@ public class ArenaEditChatListener implements Listener {
                 return;
             }
 
-            // Reload arenas so timer/hardcore changes actually apply
-            plugin.getArenaManager().reload();
+            if (!plugin.getArenaManager().reloadArena(edit.arenaId)) {
+                player.sendMessage(ChatColor.YELLOW + "Saved arenas.yml, but the arena was not hot-reloaded because it is active or has players.");
+                return;
+            }
 
             player.sendMessage(ChatColor.GREEN + "Updated " + edit.key.pathKey + " to " + value + " for arena '" + edit.arenaId + "'.");
             new ArenaSettingsGui(plugin, this, edit.arenaId).open(player);

--- a/src/main/java/me/cbhud/castlesiege/gui/ArenaSelector.java
+++ b/src/main/java/me/cbhud/castlesiege/gui/ArenaSelector.java
@@ -32,7 +32,6 @@ public class ArenaSelector {
                 .create();
     }
 
-    // Removed synchronization
     private void init() {
         int slot = 0;
         for (Arena arena : arenaManager.getArenas()) {
@@ -95,11 +94,9 @@ public class ArenaSelector {
                         ? arena.getWorldName().replaceAll("\\d", "")
                         : "Unknown")
                 .replace("{type}", arena.isHardcore() ? "Hardcore" : "Normal")
-                // Add any other placeholders you need based on your Arena class methods
                 ;
     }
 
-    // Removed synchronization here as well
     private void handleArenaSelection(InventoryClickEvent event, Arena arena) {
         if (!(event.getWhoClicked() instanceof Player)) return;
         Player player = (Player) event.getWhoClicked();

--- a/src/main/java/me/cbhud/castlesiege/gui/ArenaSettingsGui.java
+++ b/src/main/java/me/cbhud/castlesiege/gui/ArenaSettingsGui.java
@@ -39,11 +39,11 @@ public class ArenaSettingsGui {
                 .rows(3)
                 .create();
 
-        boolean locked = arena.getState() == ArenaState.IN_GAME;
+        boolean locked = arena.getState() == ArenaState.IN_GAME || arena.getNoPlayers() > 0;
         if (locked) {
             gui.setItem(13, ItemBuilder.from(Material.BARRIER)
                     .name(Component.text(ChatColor.RED + "Editing disabled"))
-                    .lore(List.of(Component.text(ChatColor.GRAY + "Arena is IN_GAME. Stop it first.")))
+                    .lore(List.of(Component.text(ChatColor.GRAY + "Arena must be empty before editing.")))
                     .asGuiItem(e -> { e.setCancelled(true); })
             );
         }
@@ -91,7 +91,7 @@ public class ArenaSettingsGui {
         Material mat = hardcore ? Material.LIME_DYE : Material.GRAY_DYE;
         List<Component> lore = new ArrayList<>();
         lore.add(Component.text(ChatColor.GRAY + "Current: " + (hardcore ? "true" : "false")));
-        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while IN_GAME" : "Click to toggle")));
+        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while arena has players" : "Click to toggle")));
 
         return ItemBuilder.from(mat)
                 .name(Component.text(ChatColor.GOLD + "Hardcore"))
@@ -103,9 +103,11 @@ public class ArenaSettingsGui {
                     boolean newValue = !hardcore;
                     boolean ok = ArenaYmlEditor.setBoolean(plugin, arenaId, "hardcore", newValue);
                     if (ok) {
-                        plugin.getArenaManager().reload();
-                        ((Player) e.getWhoClicked()).sendMessage(ChatColor.GREEN + "Hardcore set to " + newValue);
-                        open((Player) e.getWhoClicked());
+                        Player player = (Player) e.getWhoClicked();
+                        if (reloadEditedArena(player)) {
+                            player.sendMessage(ChatColor.GREEN + "Hardcore set to " + newValue);
+                            open(player);
+                        }
                     } else {
                         ((Player) e.getWhoClicked()).sendMessage(ChatColor.RED + "Failed to save arenas.yml");
                     }
@@ -117,7 +119,7 @@ public class ArenaSettingsGui {
 
         List<Component> lore = new ArrayList<>();
         lore.add(Component.text(ChatColor.GRAY + "Current: " + value));
-        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while IN_GAME" : "Click to edit (chat input)")));
+        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while arena has players" : "Click to edit (chat input)")));
 
         return ItemBuilder.from(mat)
                 .name(Component.text(ChatColor.GOLD + title))
@@ -132,7 +134,8 @@ public class ArenaSettingsGui {
     private void startChatEdit(InventoryClickEvent e, ArenaEditChatListener.PendingKey key) {
         if (!(e.getWhoClicked() instanceof Player player)) return;
         player.closeInventory();
-        chat.begin(player, arenaId, key);    }
+        chat.begin(player, arenaId, key);
+    }
 
     private GuiItem spawnSetterItem(String key, String title, Material mat, boolean locked) {
         String raw = ArenaYmlEditor.getSpawnRaw(plugin, arenaId, key);
@@ -140,7 +143,7 @@ public class ArenaSettingsGui {
         List<Component> lore = new ArrayList<>();
         lore.add(Component.text(ChatColor.GRAY + "Current:"));
         lore.add(Component.text(ChatColor.DARK_GRAY + raw));
-        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while IN_GAME" : "Click to set to your position")));
+        lore.add(Component.text(ChatColor.DARK_GRAY + (locked ? "Locked while arena has players" : "Click to set to your position")));
 
         return ItemBuilder.from(mat)
                 .name(Component.text(ChatColor.GOLD + title))
@@ -152,12 +155,22 @@ public class ArenaSettingsGui {
 
                     boolean ok = ArenaYmlEditor.setSpawn(plugin, arenaId, key, p.getLocation());
                     if (ok) {
-                        plugin.getArenaManager().reload();
-                        p.sendMessage(ChatColor.GREEN + "Updated " + key + " for arena '" + arenaId + "'.");
-                        open(p);
+                        if (reloadEditedArena(p)) {
+                            p.sendMessage(ChatColor.GREEN + "Updated " + key + " for arena '" + arenaId + "'.");
+                            open(p);
+                        }
                     } else {
                         p.sendMessage(ChatColor.RED + "Failed to save arenas.yml");
                     }
                 });
+    }
+
+    private boolean reloadEditedArena(Player player) {
+        if (plugin.getArenaManager().reloadArena(arenaId)) {
+            return true;
+        }
+
+        player.sendMessage(ChatColor.YELLOW + "Saved arenas.yml, but the arena was not hot-reloaded because it is active or has players.");
+        return false;
     }
 }

--- a/src/main/java/me/cbhud/castlesiege/kit/KitManager.java
+++ b/src/main/java/me/cbhud/castlesiege/kit/KitManager.java
@@ -27,7 +27,7 @@ public class KitManager {
         createKitsFileIfNotExists();
         kits = new ArrayList<>();
         kits = loadKits();
-        syncKitsToDatabase();
+        syncKitsToDatabaseAsync();
     }
 
     // Load kits from kits.yml
@@ -196,10 +196,12 @@ public class KitManager {
         }
     }
 
-    public void syncKitsToDatabase() {
-        for (KitData kit : kits) {
-            saveOrUpdateKitInDatabase(kit);
-        }
+    public void syncKitsToDatabaseAsync() {
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+            for (KitData kit : kits) {
+                saveOrUpdateKitInDatabase(kit);
+            }
+        });
     }
 }
 

--- a/src/main/java/me/cbhud/castlesiege/kit/PlayerKitManager.java
+++ b/src/main/java/me/cbhud/castlesiege/kit/PlayerKitManager.java
@@ -8,9 +8,10 @@ import org.bukkit.inventory.ItemStack;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class PlayerKitManager {
-    private final Map<Player, KitManager.KitData> selectedKits;
+    private final Map<UUID, KitManager.KitData> selectedKits;
     private final CastleSiege plugin;
 
     public PlayerKitManager(CastleSiege plugin) {
@@ -19,10 +20,7 @@ public class PlayerKitManager {
     }
 
     public boolean hasSelectedKit(Player player){
-        if (selectedKits.containsKey(player)){
-            return true;
-        }
-        return false;
+        return player != null && selectedKits.containsKey(player.getUniqueId());
     }
 
     public void giveKit(Player player, KitManager.KitData kit) {
@@ -32,7 +30,7 @@ public class PlayerKitManager {
         }
 
         equipArmor(player, kit.getItems());
-        selectedKits.put(player, kit);
+        selectedKits.put(player.getUniqueId(), kit);
     }
 
     public void selectKit(Player player, KitManager.KitData kit) {
@@ -41,14 +39,15 @@ public class PlayerKitManager {
             return;
         }
 
-        if (kit.getTeam() != plugin.getArenaManager().getArenaByPlayer(player.getUniqueId()).getTeam(player)) {
+        if (plugin.getArenaManager().getArenaByPlayer(player.getUniqueId()) == null
+                || kit.getTeam() != plugin.getArenaManager().getArenaByPlayer(player.getUniqueId()).getTeam(player)) {
             player.sendMessage(plugin.getMsg().getMessage("opposingTeamKit", player).get(0));
             return;
         }
 
         if (kit.getPrice() == 0) {
-            selectedKits.put(player, kit);
-            plugin.getScoreboardManager().updateScoreboard(player, "pre-game");
+            selectedKits.put(player.getUniqueId(), kit);
+            plugin.updateScoreboard(player, "pre-game");
             String msg = plugin.getMsg().getMessage("selectedKit", player).get(0);
             msg = msg.replace("{kit}", kit.getName());
             player.sendMessage(msg);
@@ -58,8 +57,8 @@ public class PlayerKitManager {
         plugin.getDataManager().hasPlayerKit(player.getUniqueId(), kit.getName()).thenAccept(hasKit -> {
             org.bukkit.Bukkit.getScheduler().runTask(plugin, () -> {
                 if (hasKit) {
-                    selectedKits.put(player, kit);
-                    plugin.getScoreboardManager().updateScoreboard(player, "pre-game");
+                    selectedKits.put(player.getUniqueId(), kit);
+                    plugin.updateScoreboard(player, "pre-game");
                     String msg = plugin.getMsg().getMessage("selectedKit", player).get(0);
                     msg = msg.replace("{kit}", kit.getName());
                     player.sendMessage(msg);
@@ -72,7 +71,7 @@ public class PlayerKitManager {
 
 
     public KitManager.KitData getSelectedKit(Player player) {
-        return selectedKits.get(player);
+        return player == null ? null : selectedKits.get(player.getUniqueId());
     }
 
     public int getKitPrice(KitManager.KitData kit) {
@@ -123,7 +122,13 @@ public class PlayerKitManager {
             return;
         }
 
-        selectedKits.put(player, defaultKit);
+        selectedKits.put(player.getUniqueId(), defaultKit);
+    }
+
+    public void clearSelectedKit(Player player) {
+        if (player != null) {
+            selectedKits.remove(player.getUniqueId());
+        }
     }
 
 

--- a/src/main/java/me/cbhud/castlesiege/player/PlayerManager.java
+++ b/src/main/java/me/cbhud/castlesiege/player/PlayerManager.java
@@ -80,7 +80,7 @@ public class PlayerManager {
                 player.teleport(getLobbyLocation());
             }
 
-            plugin.getScoreboardManager().setupScoreboard(player);
+            plugin.setupScoreboard(player);
         });
     }
 
@@ -112,7 +112,7 @@ public class PlayerManager {
 
             playerStates.put(player.getUniqueId(), WAITING);
 
-            plugin.getScoreboardManager().updateScoreboard(player, "pre-game");
+            plugin.updateScoreboard(player, "pre-game");
         });
     }
 

--- a/src/main/java/me/cbhud/castlesiege/scoreboard/ScoreboardManager.java
+++ b/src/main/java/me/cbhud/castlesiege/scoreboard/ScoreboardManager.java
@@ -179,7 +179,7 @@ public class ScoreboardManager {
         return out;
     }
 
-    // Currently unused; kept for future use safely
+    // I keep this available for future gradient support.
     @SuppressWarnings("unused")
     private String applyGradient(String text) {
         if (text == null || text.isEmpty()) return "";

--- a/src/main/java/me/cbhud/castlesiege/team/TeamManager.java
+++ b/src/main/java/me/cbhud/castlesiege/team/TeamManager.java
@@ -151,9 +151,9 @@ public class TeamManager {
         // Messaging
         safeTeamJoinMsg(player, newTeam);
 
-        // Side effects (kept as you had)
+        // I refresh kit and scoreboard state after a team change.
         plugin.getPlayerKitManager().setDefaultKit(player);
-        plugin.getScoreboardManager().updateScoreboard(player, "pre-game");
+        plugin.updateScoreboard(player, "pre-game");
 
         return true;
     }

--- a/src/main/java/me/cbhud/castlesiege/utils/BossBar.java
+++ b/src/main/java/me/cbhud/castlesiege/utils/BossBar.java
@@ -129,12 +129,8 @@ public class BossBar {
         playerTasks.put(playerId, task);
     }
 
-    // Your original method - now creates individual boss bars for each player
     public void showZombieHealthBar(Zombie zombie) {
-        // This method can now be used in a foreach loop
-        // You'll need to pass the player parameter, or modify to get nearby players
-
-        // Example: Show to all online players (you can modify this logic)
+        // I show the King health bar to every online player.
         for (Player player : plugin.getServer().getOnlinePlayers()) {
             showZombieHealthBarToPlayer(zombie, player);
         }

--- a/src/main/java/me/cbhud/castlesiege/utils/ConfigManager.java
+++ b/src/main/java/me/cbhud/castlesiege/utils/ConfigManager.java
@@ -26,10 +26,13 @@ public class ConfigManager {
         }
 
         config = YamlConfiguration.loadConfiguration(configFile);
-        // Add defaults for nametag prefixes if missing
         boolean changed = false;
-        if (!config.contains("attackersNametagPrefix")) { config.set("attackersNametagPrefix", "&c"); changed = true; }
-        if (!config.contains("defendersNametagPrefix")) { config.set("defendersNametagPrefix", "&b"); changed = true; }
+        if (!config.contains("boss-bar.enabled")) {
+            config.set("boss-bar.enabled", config.getBoolean("bossbar-enabled", true));
+            changed = true;
+        }
+        if (!config.contains("attackers-nametag-color")) { config.set("attackers-nametag-color", "&c"); changed = true; }
+        if (!config.contains("defenders-nametag-color")) { config.set("defenders-nametag-color", "&9"); changed = true; }
         if (changed) saveConfig();
     }
 
@@ -78,29 +81,26 @@ public class ConfigManager {
     }
 
     public boolean getBossBarEnabled() {
-        return  config.getBoolean("boss-bar.enabled", true);
+        return config.getBoolean("boss-bar.enabled", config.getBoolean("bossbar-enabled", true));
     }
 
     public ChatColor getDefendersColor() {
         String colorCode = config.getString("defenders-nametag-color", "&9");
-
-        char codeChar = colorCode.charAt(1);
-
-        ChatColor color = ChatColor.getByChar(codeChar);
-
-        // Provide a safe fallback in case someone typos the config
-        return color != null ? color : ChatColor.BLUE;
+        return parseColor(colorCode, ChatColor.BLUE);
     }
 
     public ChatColor getAttackersColor() {
         String colorCode = config.getString("attackers-nametag-color", "&c");
+        return parseColor(colorCode, ChatColor.RED);
+    }
 
-        char codeChar = colorCode.charAt(1);
+    private ChatColor parseColor(String colorCode, ChatColor fallback) {
+        if (colorCode == null || colorCode.length() < 2 || colorCode.charAt(0) != '&') {
+            return fallback;
+        }
 
-        ChatColor color = ChatColor.getByChar(codeChar);
-
-        // Provide a safe fallback in case someone typos the config
-        return color != null ? color : ChatColor.RED;
+        ChatColor color = ChatColor.getByChar(colorCode.charAt(1));
+        return color != null ? color : fallback;
     }
 
 }

--- a/src/main/java/me/cbhud/castlesiege/utils/CustomPlaceholder.java
+++ b/src/main/java/me/cbhud/castlesiege/utils/CustomPlaceholder.java
@@ -92,7 +92,7 @@ public class CustomPlaceholder extends PlaceholderExpansion {
             case "arena":
                 return getArenaId(arena);
             case "arenasize":
-                return String.valueOf(getArenaSize(arena)); // ✅ fixed
+                return String.valueOf(getArenaSize(arena));
             case "arena_type":
                 return getArenaType(arena);
             case "team":
@@ -190,7 +190,7 @@ public class CustomPlaceholder extends PlaceholderExpansion {
     }
 
     private int getArenaSize(Arena arena) {
-        // ✅ FIX: Arena no longer has getPlayers()
+        // I read the arena membership count from its UUID set.
         return arena != null ? arena.getNoPlayers() : 0;
     }
 

--- a/src/main/java/me/cbhud/castlesiege/utils/DataManager.java
+++ b/src/main/java/me/cbhud/castlesiege/utils/DataManager.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public class DataManager {
     private final CastleSiege plugin;
@@ -80,7 +81,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Boolean> hasPlayerKit(UUID playerUUID, String kitName) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String sql = """
             SELECT 1
             FROM player_kits pk
@@ -107,7 +108,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Boolean> hasData(UUID uuid) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String sql = "SELECT 1 FROM player_stats WHERE uuid = ? LIMIT 1";
 
             try (Connection conn = dataSource.getConnection();
@@ -143,24 +144,16 @@ public class DataManager {
         });
     }
 
-    public void incrementWins(UUID uuid, int coinsToAdd) {
+    public void incrementWins(UUID uuid) {
         String updateWinsSql = "UPDATE player_stats SET wins = wins + 1 WHERE uuid = ?";
-        String updateCoinsSql = "UPDATE player_stats SET coins = coins + ? WHERE uuid = ?";
 
         new BukkitRunnable() {
             @Override
             public void run() {
-                try (Connection conn = dataSource.getConnection()) {
-                    try (PreparedStatement statement = conn.prepareStatement(updateWinsSql)) {
-                        statement.setString(1, uuid.toString());
-                        statement.executeUpdate();
-                    }
-
-                    try (PreparedStatement coinsStatement = conn.prepareStatement(updateCoinsSql)) {
-                        coinsStatement.setInt(1, coinsToAdd);
-                        coinsStatement.setString(2, uuid.toString());
-                        coinsStatement.executeUpdate();
-                    }
+                try (Connection conn = dataSource.getConnection();
+                     PreparedStatement statement = conn.prepareStatement(updateWinsSql)) {
+                    statement.setString(1, uuid.toString());
+                    statement.executeUpdate();
                 } catch (SQLException e) {
                     e.printStackTrace();
                 }
@@ -211,7 +204,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Integer> getPlayerKills(UUID uuid) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String getKillsSql = "SELECT kills FROM player_stats WHERE uuid = ?";
 
             try (Connection conn = dataSource.getConnection();
@@ -230,7 +223,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Integer> getPlayerWins(UUID uuid) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String getWinsSql = "SELECT wins FROM player_stats WHERE uuid = ?";
 
             try (Connection conn = dataSource.getConnection();
@@ -249,7 +242,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Integer> getPlayerDeaths(UUID uuid) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String getDeathsSql = "SELECT deaths FROM player_stats WHERE uuid = ?";
 
             try (Connection conn = dataSource.getConnection();
@@ -268,7 +261,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Integer> getPlayerCoins(UUID uuid) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String getCoinsSql = "SELECT coins FROM player_stats WHERE uuid = ?";
 
             try (Connection conn = dataSource.getConnection();
@@ -330,7 +323,7 @@ public class DataManager {
     }
 
     public CompletableFuture<Boolean> unlockPlayerKit(UUID uuid, String kitName, int kitPrice) {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String checkCoinsSql = "SELECT coins FROM player_stats WHERE uuid = ?";
             String updateCoinsSql = "UPDATE player_stats SET coins = coins - ? WHERE uuid = ?";
             String unlockKitSql = """
@@ -382,7 +375,7 @@ public class DataManager {
     }
 
     public CompletableFuture<List<String>> getTopWins() {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String sql = "SELECT username, wins FROM player_stats ORDER BY wins DESC LIMIT 10";
             List<String> topWins = new ArrayList<>();
 
@@ -406,7 +399,7 @@ public class DataManager {
     }
 
     public CompletableFuture<List<String>> getTopDeaths() {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String sql = "SELECT username, deaths FROM player_stats ORDER BY deaths DESC LIMIT 10";
             List<String> topDeaths = new ArrayList<>();
 
@@ -430,7 +423,7 @@ public class DataManager {
     }
 
     public CompletableFuture<List<String>> getTopKills() {
-        return CompletableFuture.supplyAsync(() -> {
+        return supplyDatabaseAsync(() -> {
             String sql = "SELECT username, kills FROM player_stats ORDER BY kills DESC LIMIT 10";
             List<String> topKills = new ArrayList<>();
 
@@ -469,5 +462,17 @@ public class DataManager {
             dataSource.close();
             plugin.getLogger().info("Database connection pool closed.");
         }
+    }
+
+    private <T> CompletableFuture<T> supplyDatabaseAsync(Supplier<T> supplier) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                future.complete(supplier.get());
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        });
+        return future;
     }
 }

--- a/src/main/java/me/cbhud/castlesiege/utils/MobManager.java
+++ b/src/main/java/me/cbhud/castlesiege/utils/MobManager.java
@@ -84,9 +84,8 @@ public class MobManager implements Listener {
     }
 
     /**
-     * ✅ FIX #1: Return the actual king zombie.
-     * - If stored kingZombie is valid and in this world, return it.
-     * - Otherwise scan zombies in the given world and pick the one named "King".
+     * I return the King zombie for the requested world.
+     * If my cached reference is stale, I scan named zombies in that world and rebind it.
      */
     public Zombie getKingZombie(World world) {
         if (world == null) return null;
@@ -111,7 +110,7 @@ public class MobManager implements Listener {
     @EventHandler
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
 
-        // ✅ TNT logic unchanged (as requested)
+        // I prevent TNT from damaging the King while still allowing configured player damage.
         if (event.getDamager() instanceof TNTPrimed) {
 
             if (event.getEntity() instanceof Zombie) {
@@ -134,7 +133,7 @@ public class MobManager implements Listener {
                 return;
             }
 
-            // ✅ FIX #3: null-safe arena lookup
+            // I ignore zombie damage if the attacker is no longer mapped to an arena.
             Arena arena = plugin.getArenaManager().getArenaByPlayer(damager.getUniqueId());
             if (arena == null) return;
 
@@ -150,7 +149,7 @@ public class MobManager implements Listener {
 
             if (!(projectile.getShooter() instanceof Player shooter)) return;
 
-            // ✅ FIX #3: null-safe arena lookup
+            // I ignore projectile damage if the shooter is no longer mapped to an arena.
             Arena arena = plugin.getArenaManager().getArenaByPlayer(shooter.getUniqueId());
             if (arena == null) return;
 
@@ -234,7 +233,7 @@ public class MobManager implements Listener {
             plugin.getLogger().warning("King death effect failed: " + ex.getMessage());
         }
 
-        // ✅ FIX #4: end game safely
+        // I resolve the arena from the killer first, then fall back to the King world.
         Arena arena = null;
 
         Player killer = zombie.getKiller();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,11 +10,12 @@ attackersTeamName: Attackers
 defendersTeamName: Defenders
 
 ##CHANGE TEAM NAMETAG PLATE COLORS
-defenders-nametag-color: &9
-attackers-nametag-color: &c
+defenders-nametag-color: "&9"
+attackers-nametag-color: "&c"
 
 ##BOSSBAR FOR KING HEALTH ENABLE OR DISABLE
-bossbar-enabled: true
+boss-bar:
+  enabled: true
 
 ##ADJUST COINS PER KILL AND WIN
 coins-on-win: 3

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -64,6 +64,9 @@ starting-in:
 selectedKit:
   - "&aYou have selected the {kit} kit!"
 
+win-coins-received:
+  - "&aYou received &6{coins} &acoins for winning!"
+
 lockedKit:
   - "&cYou do not have this kit unlocked. Right-click to purchase it."
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,12 +1,11 @@
 name: CastleSiege
-version: '2.1.0'
+version: '2.1.1'
 main: me.cbhud.castlesiege.CastleSiege
 author: cbhud
 api-version: '1.20'
-depend: [Regenerato]
+depend: [Regenerato, FastAsyncWorldEdit]
 softdepend:
   - PlaceholderAPI
-  - FastAsyncWorldEdit
   - Multiverse-Core
 commands:
   cse:

--- a/src/main/resources/scoreboards.yml
+++ b/src/main/resources/scoreboards.yml
@@ -1,4 +1,5 @@
 settings:
+  enabled: true
   auto-refresh:
     enabled: true
 ## 20 ticks = 1 second


### PR DESCRIPTION
- require FAWE explicitly and make WorldEdit compatibility optional
- add scoreboards.yml master enabled switch and skip scoreboard initialization when disabled
- refactor right-click handling into focused interaction handlers
- store selected kits by UUID and clear kit/cooldown state on quit
- move database futures and kit sync onto Bukkit async scheduler
- fix win coin reward accounting and add configurable win reward message
- reload only the edited empty arena from setup/editor flows
- handle zero-defender edge case and safely guard King bossbar display
- normalize config naming and clean up comments